### PR TITLE
Add Necessary NuGet Packages and Cleanup GameServer Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 # Soviet Manager Backend
 
-[![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)  
-[![ASP.NET Core](https://img.shields.io/badge/ASP.NET%20Core-8.0-blue)](https://dotnet.microsoft.com/apps/aspnet)
-[![C#](https://img.shields.io/badge/C%23-8.0-239120)](https://docs.microsoft.com/en-us/dotnet/csharp/)  
-[![SignalR](https://img.shields.io/badge/SignalR-2.4.1-blue)](https://dotnet.microsoft.com/apps/aspnet/signalr)
-[![MessagePack](https://img.shields.io/badge/MessagePack-2.1.80-blue)](https://github.com/neuecc/MessagePack-CSharp)  
-[![Postgres](https://img.shields.io/badge/Postgres-13-blue)](https://www.postgresql.org/)
-[![Entity Framework](https://img.shields.io/badge/Entity%20Framework-6.4.4-blue)](https://docs.microsoft.com/en-us/ef/)  
-[![Docker](https://img.shields.io/badge/Docker-19.03-blue)](https://www.docker.com/)
+## Core Technologies
+[![.NET Core](https://img.shields.io/badge/.NET_Core-8.0-blueviolet)](https://dotnet.microsoft.com/download/dotnet/8.0)
+[![ASP.NET Core](https://img.shields.io/badge/ASP.NET_Core-8.0-blue)](https://docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-8.0)
+
+## Database
+[![Entity Framework Core](https://img.shields.io/badge/Entity_Framework_Core-8.0-green)](https://docs.microsoft.com/en-us/ef/core/)
+[![Npgsql](https://img.shields.io/badge/Npgsql-8.0.4-blue)](https://www.npgsql.org/)
+
+## Real-Time Communication
+[![SignalR](https://img.shields.io/badge/SignalR-8.0-lightgrey)](https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-8.0)
+[![MessagePack for SignalR](https://img.shields.io/badge/MessagePack_for_SignalR-8.0-orange)](https://docs.microsoft.com/en-us/aspnet/core/signalr/messagepackhubprotocol?view=aspnetcore-8.0)
+
+## Serialization
+[![Newtonsoft.Json](https://img.shields.io/badge/Newtonsoft.Json-13.0.3-yellowgreen)](https://www.newtonsoft.com/json)
+[![JsonWebTokens](https://img.shields.io/badge/JsonWebTokens-7.6.2-yellow)](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/docs/json-web-tokens.md)
+
+## Testing
+[![InMemory](https://img.shields.io/badge/EFCore.InMemory-8.0.6-lightblue)](https://docs.microsoft.com/en-us/ef/core/providers/in-memory/?tabs=dotnet-core-cli)
+
+## Deployment
+[![Docker](https://img.shields.io/badge/Docker-Enabled-blue)](https://www.docker.com/)
+
 
 Welcome to the Soviet Manager Backend repository. This project is the server-side application for the Soviet Manager game, designed to handle game logic, player interactions, and data management.
 
@@ -24,27 +38,9 @@ Welcome to the Soviet Manager Backend repository. This project is the server-sid
 
 ## Project Structure
 
-The repository is structured as follows:
+This project is currently under active development. As a result, the project structure is subject to significant changes. The final structure will be documented once the project reaches a more stable state. For now, please note that the organization of files and folders is evolving to best suit the needs of the development process.
 
-```plaintext
-soviet-manager-backend/
-├── docs/
-│   ├── BranchNamingConvention.md
-│   ├── CodeStyleConvention.md
-├── src/
-│   └── GameServer/
-│       ├── Controllers/
-│       ├── Properties/
-│       ├── appsettings.json
-│       ├── Dockerfile
-│       ├── GameServer.http
-│       ├── Program.cs
-│       ├── WeatherForecast.cs
-├── .dockerignore
-├── .gitattributes
-├── .gitignore
-├── SovietManagerBackend.sln
-```
+We appreciate your understanding and patience as we work towards building a robust and well-organized system.
 
 ## Setup Instructions
 

--- a/src/GameServer/GameServer.csproj
+++ b/src/GameServer/GameServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,6 +10,18 @@
 
   <ItemGroup>
     <Folder Include="Controllers\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes the following changes:

- Imported necessary NuGet packages to initialize the project, including:
  - `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` (v8.0.6)
  - `Microsoft.EntityFrameworkCore.InMemory` (v8.0.6)
  - `Microsoft.EntityFrameworkCore.Tools` (v8.0.6)
  - `Microsoft.IdentityModel.JsonWebTokens` (v7.6.2)
  - `Newtonsoft.Json` (v13.0.3)
  - `Npgsql.EntityFrameworkCore.PostgreSQL` (v8.0.4)
- Cleaned up the `GameServer` project structure.
- Updated the `README.md` to reflect the current state of the project, including badges for core technologies, database, real-time communication, serialization, testing, and deployment.

These changes set up the necessary infrastructure for further development and improve the overall organization of the project.